### PR TITLE
Changes to --resources argument

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func RootCmd() *cobra.Command {
 
 	cmd.Flags().StringP(outputOption, "o", "", "Path to output markdown file (required)")
 	_ = cmd.MarkFlagRequired(outputOption)
-	cmd.Flags().StringP(resourcesOption, "r", "", "Path to directory with CustomResourceDefinition YAML files (required)")
+	cmd.Flags().StringP(resourcesOption, "r", "", "Path to YAML file or directory containing CustomResourceDefinitions (required)")
 	_ = cmd.MarkFlagRequired(resourcesOption)
 	cmd.Flags().StringP(templateOption, "t", "markdown.tmpl", "Path to file in a templates directory")
 	cmd.Flags().StringP(tocOption, "c", "", "Path to table of contents YAML file")

--- a/pkg/builder/crds.go
+++ b/pkg/builder/crds.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"io"
 	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -25,6 +26,16 @@ func LoadCRDs(dirpath string) ([]*apiextensions.CustomResourceDefinition, error)
 	files, err := filepath.Glob(path.Join(dirpath, "*"))
 	if err != nil {
 		return nil, err
+	}
+
+	// Glob ignores file system errors, so check the supplied path when there
+	// are no results. When it is a file, treat it like a single result from
+	// Glob.
+	if len(files) == 0 {
+		info, err := os.Stat(dirpath)
+		if err == nil && !info.IsDir() {
+			files = append(files, dirpath)
+		}
 	}
 
 	resources := []*apiextensions.CustomResourceDefinition{}

--- a/pkg/builder/crds.go
+++ b/pkg/builder/crds.go
@@ -30,10 +30,13 @@ func LoadCRDs(dirpath string) ([]*apiextensions.CustomResourceDefinition, error)
 
 	// Glob ignores file system errors, so check the supplied path when there
 	// are no results. When it is a file, treat it like a single result from
-	// Glob.
+	// Glob. When it does not exist, return an error.
 	if len(files) == 0 {
 		info, err := os.Stat(dirpath)
-		if err == nil && !info.IsDir() {
+		if err != nil {
+			return nil, err
+		}
+		if !info.IsDir() {
 			files = append(files, dirpath)
 		}
 	}


### PR DESCRIPTION
I would like to generate docs from a single YAML file. When I tried it, I was surprised that I got neither an error nor any docs.

I'm not sure if the lack of error is intentional, so this is broken into two commits. I'm most interested in the first, which allows the argument to `--resources` to be a single file.

Before:
```console
$ go run . --resources /does/not/exist --output /dev/stdout ; echo $?
# API Reference

Packages:
0

$ go run . --resources ./example/crds/example.yaml --output /dev/stdout ; echo $?
# API Reference

Packages:
0
```

After:
```console
$ go run . --resources /does/not/exist --output /dev/stdout ; echo $?
stat /does/not/exist: no such file or directory
exit status 1
1

$ go run . --resources ./example/crds/example.yaml --output /dev/stdout ; echo $?
# API Reference

Packages:

- [project.io/v1alpha1](#projectiov1alpha1)
…
</table>
0
```