### PR TITLE
Sort required fields before others

### DIFF
--- a/pkg/builder/properties.go
+++ b/pkg/builder/properties.go
@@ -37,10 +37,10 @@ func (s propertiesByRequired) Less(i, j int) bool {
 	}
 
 	if leftRequired && !rightRequired {
-		return false
+		return true
 	}
 	if !leftRequired && rightRequired {
-		return true
+		return false
 	}
 	return left < right
 }

--- a/pkg/builder/properties_test.go
+++ b/pkg/builder/properties_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 IBM Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+package builder
+
+import (
+	"math/rand"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestSortPropertiesByRequired(t *testing.T) {
+	shuffle := func(s []string) {
+		rand.Shuffle(len(s), func(i, j int) {
+			s[i], s[j] = s[j], s[i]
+		})
+	}
+
+	sorter := propertiesByRequired{}
+
+	// No required; sorts alphabetically.
+	sorter.properties = []string{"a", "b", "c", "d"}
+	shuffle(sorter.properties)
+	sort.Sort(sorter)
+
+	if !reflect.DeepEqual(sorter.properties, []string{"a", "b", "c", "d"}) {
+		t.Fatalf("wrong order, got %v", sorter.properties)
+	}
+
+	// Required first.
+	sorter.required = []string{"b", "d"}
+	shuffle(sorter.properties)
+	sort.Sort(sorter)
+
+	if !reflect.DeepEqual(sorter.properties, []string{"b", "d", "a", "c"}) {
+		t.Fatalf("wrong order, got %v", sorter.properties)
+	}
+
+	// All required; sorts alphabetically.
+	sorter.required = []string{"a", "b", "c", "d"}
+	shuffle(sorter.properties)
+	sort.Sort(sorter)
+
+	if !reflect.DeepEqual(sorter.properties, []string{"a", "b", "c", "d"}) {
+		t.Fatalf("wrong order, got %v", sorter.properties)
+	}
+}


### PR DESCRIPTION
I noticed that required fields were always rendered last. It appears they are intended to be first. This inverts the sort criteria and adds a test.

https://github.com/fybrik/crdoc/blob/47f39780a36f8c4400af19b411d6fd3607f6031a/pkg/builder/properties.go#L48-L50