### PR TITLE
Add HTML ecape function

### DIFF
--- a/pkg/functions/functions.go
+++ b/pkg/functions/functions.go
@@ -3,8 +3,11 @@
 
 package functions
 
+import "html"
+
 var ExportedMap = map[string]interface{}{
 	// Strings
 	"anchorize":          Anchorize,
 	"anchorizeAsciiOnly": AnchorizeAsciiOnly,
+	"escape":             html.EscapeString,
 }


### PR DESCRIPTION
When running yaml files, some data inside the yaml can break the HTML
tables, and there is no way to escape the chars natively.

This commits adds a way to escape variable:

```{{escape .Description}}```

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>