### PR TITLE
Remove the redundant  option

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,4 +20,3 @@ jobs:
         with:
           version: v1.29
           args: --timeout 5m
-          skip-go-installation: true


### PR DESCRIPTION
Remove the redundant `skip-go-installation` option" from `golangci-lint-action`

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>