### PR TITLE
Fix go mod tidy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,6 @@ jobs:
           go run main.go --resources example/crds --output example/output.md
       - name: Check that there are no source code changes
         run: |
-          go mod tidy
+          go mod tidy -compat=1.17
           git checkout go.sum
           git diff --exit-code

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,12 @@
 
 # Generated e.g. by LineCount and the example usage command
 out/
+
+# editor and IDE paraphernalia
+.idea
+*.swp
+*.swo
+*~
+.vscode
+.history
+.netrc


### PR DESCRIPTION
-  add `-compat=1.17` to `go mod tidy`
- add # editor and IDE paraphernalia to .gitignore
