### PR TITLE
feat: Add XValidations in the generated documentation

### DIFF
--- a/pkg/builder/properties.go
+++ b/pkg/builder/properties.go
@@ -128,6 +128,10 @@ func getEnrichedProperty(schema *apiextensions.JSONSchemaProps, fieldName string
 		if property.Required == nil {
 			property.Required = validationProperty.Required
 		}
+		if property.XValidations == nil {
+			property.XValidations = validationProperty.XValidations
+		}
+
 	}
 
 	return property

--- a/templates/adoc.tmpl
+++ b/templates/adoc.tmpl
@@ -57,6 +57,13 @@ Resource Types:
 | {{.Type}}
 a| {{.Description}}
 
+{{if .Schema.XValidations -}}
+* _Validations_:
+{{- range .Schema.XValidations -}}
+** {{ .Rule }}: {{ .Message }}
+{{- end -}}
+{{end -}}
+
 {{ if .Schema.Format -}}
 * _Format_: {{ .Schema.Format }}
 {{ end -}}

--- a/templates/frontmatter.tmpl
+++ b/templates/frontmatter.tmpl
@@ -72,9 +72,15 @@ Resource Types:
         <td>{{.Type}}</td>
         <td>
           {{.Description}}<br/>
-          {{- if or .Schema.Format .Schema.Enum .Schema.Default .Schema.Minimum .Schema.Maximum }}
+          {{- if or .Schema.XValidations .Schema.Format .Schema.Enum .Schema.Default .Schema.Minimum .Schema.Maximum }}
           <br/>
           {{- end}}
+          {{- if .Schema.XValidations }}
+            <i>Validations</i>:
+            {{- range .Schema.XValidations -}}
+              <li>{{ .Rule }}: {{ .Message }}</li>
+            {{- end -}}
+          {{- end }}
           {{- if .Schema.Format }}
             <i>Format</i>: {{ .Schema.Format }}<br/>
           {{- end }}

--- a/templates/markdown.tmpl
+++ b/templates/markdown.tmpl
@@ -66,9 +66,15 @@ Resource Types:
         <td>{{.Type}}</td>
         <td>
           {{.Description}}<br/>
-          {{- if or .Schema.Format .Schema.Enum .Schema.Default .Schema.Minimum .Schema.Maximum }}
+          {{- if or .Schema.XValidations .Schema.Format .Schema.Enum .Schema.Default .Schema.Minimum .Schema.Maximum }}
           <br/>
           {{- end}}
+          {{- if .Schema.XValidations }}
+            <i>Validations</i>:
+            {{- range .Schema.XValidations -}}
+              <li>{{ .Rule }}: {{ .Message }}</li>
+            {{- end -}}
+          {{- end }}
           {{- if .Schema.Format }}
             <i>Format</i>: {{ .Schema.Format }}<br/>
           {{- end }}


### PR DESCRIPTION
With Kubernetes 1.25, CEL will be added, as an alternative to enforcing validations, rather than webhooks. This allows, among other things, the ability to enforce immutability on fields.

Since this is documented in the CRD YAML itself, bubbling this up into the documentation allows one to see custom validation rules

An example kubebuilder comment in Go would be:

```
// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Value is immutable"
```

This would result in the following in the CRD:

```
x-kubernetes-validations:
- message: Value is immutable
  rule: self == oldSelf
```

And now the generated documentation will reflect this:

```
<i>Validations</i>:<li>self == oldSelf: Value is immutable</li>
```